### PR TITLE
Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ IAMRoleAnywhereSession will take multiple arguments:
 | session_duration | The duration, in seconds, of the role session. The value specified can  range from 900 seconds (15 minutes) up to 3600 seconds (1 hour). | int           |     3600      |
 | service_name     | An identifier for the service, used to build the botosession.                                                                            | string        | rolesanywhere |
 | endpoint         | Roles Anywhere API endpoint to use                                                                                                       | string        | {service_name}.{region_name}.amazonaws.com' |
+| proxy         | Proxy endpoint(s) for use behind private networks with a proxy, defaults to `{}`                                                                                                       | dict        | {'https': "http://URL:PORT", 'http': "http://URL:PORT"} |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 
 This package provides an easy way to create a __refreshable__ boto3 Session with [AWS Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/Welcome.html).
 
-This package implements the algorithm described here: https://docs.aws.amazon.com/rolesanywhere/latest/userguide/authentication-sign-process.html.
-
+This package implements the algorithm described here: <https://docs.aws.amazon.com/rolesanywhere/latest/userguide/authentication-sign-process.html>.
 
 ## Requirements
 
@@ -40,21 +39,20 @@ For this package to work you will need to have at your disposal your `certificat
 
 IAMRoleAnywhereSession will take multiple arguments:
 
-| Name             | Description                                                                                                                              | Type          | Default value |
-|------------------|------------------------------------------------------------------------------------------------------------------------------------------|---------------|---------------|
-| profile_arn      | The Amazon Resource Name (ARN) of the profile.                                                                                           | string        |     None      |
-| role_arn         | The Amazon Resource Name (ARN) of the role to assume.                                                                                    | string        |     None      |
-| trust_anchor_arn | The Amazon Resource Name (ARN) of the trust anchor.                                                                                      | string        |     None      |
-| certificate      | The x509 certificate file, in PEM format.                                                                                                | path or bytes |     None      |
-| private_key      | The certificate private key file, in PEM Format.                                                                                         | path or bytes |     None      |
-| passphrase       | The passphrase use to decrypt private key file.                                                                                          | string        |     None      |
-| region           | The name of the region where you configured IAM Roles Anywhere.                                                                          | string        |   us-east-1   |
-| session_duration | The duration, in seconds, of the role session. The value specified can  range from 900 seconds (15 minutes) up to 3600 seconds (1 hour). | int           |     3600      |
-| service_name     | An identifier for the service, used to build the botosession.                                                                            | string        | rolesanywhere |
-| endpoint         | Roles Anywhere API endpoint to use                                                                                                       | string        | {service_name}.{region_name}.amazonaws.com' |
-| proxy         | Proxy endpoint(s) for use behind private networks with a proxy, defaults to `{}`                                                                                                       | dict        | {'https': "http://URL:PORT", 'http': "http://URL:PORT"} |
-
-## Usage
+| Name             | Description                                                                                                                              | Type          | Default value                                |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------- | -------------------------------------------- |
+| profile_arn      | The Amazon Resource Name (ARN) of the profile.                                                                                           | string        | None                                         |
+| role_arn         | The Amazon Resource Name (ARN) of the role to assume.                                                                                    | string        | None                                         |
+| trust_anchor_arn | The Amazon Resource Name (ARN) of the trust anchor.                                                                                      | string        | None                                         |
+| certificate      | The x509 certificate file, in PEM format.                                                                                                | path or bytes | None                                         |
+| private_key      | The certificate private key file, in PEM Format.                                                                                         | path or bytes | None                                         |
+| passphrase       | The passphrase use to decrypt private key file.                                                                                          | string        | None                                         |
+| region           | The name of the region where you configured IAM Roles Anywhere.                                                                          | string        | us-east-1                                    |
+| session_duration | The duration, in seconds, of the role session. The value specified can  range from 900 seconds (15 minutes) up to 3600 seconds (1 hour). | int           | 3600                                         |
+| service_name     | An identifier for the service, used to build the botosession.                                                                            | string        | rolesanywhere                                |
+| endpoint         | Roles Anywhere API endpoint to use                                                                                                       | string        | '{service_name}.{region_name}.amazonaws.com' |
+| proxies          | Proxy endpoint(s) for use behind private networks with a proxy.                                                                          | dict          | `{}`                                         |
+| proxies_config   | A dictionary of additional proxy configurations.                                                                                         | dict          | `{}`                                         |
 
 ```python
 from iam_rolesanywhere_session import IAMRolesAnywhereSession

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,3 +36,22 @@ python3 -m pip install ./
 ## Configuration
 
 For this package to work you will need to have at your disposal your `certificate` and `private_key` file in a PEM format.
+
+### Configuration Parameters
+
+IAMRoleAnywhereSession will take multiple arguments:
+
+| Name             | Description                                                                                                                              | Type          | Default value                               |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------------------------------------- |
+| profile_arn      | The Amazon Resource Name (ARN) of the profile.                                                                                           | string        | None                                        |
+| role_arn         | The Amazon Resource Name (ARN) of the role to assume.                                                                                    | string        | None                                        |
+| trust_anchor_arn | The Amazon Resource Name (ARN) of the trust anchor.                                                                                      | string        | None                                        |
+| certificate      | The x509 certificate file, in PEM format.                                                                                                | path or bytes | None                                        |
+| private_key      | The certificate private key file, in PEM Format.                                                                                         | path or bytes | None                                        |
+| passphrase       | The passphrase use to decrypt private key file.                                                                                          | string        | None                                        |
+| region           | The name of the region where you configured IAM Roles Anywhere.                                                                          | string        | us-east-1                                   |
+| session_duration | The duration, in seconds, of the role session. The value specified can  range from 900 seconds (15 minutes) up to 3600 seconds (1 hour). | int           | 3600                                        |
+| service_name     | An identifier for the service, used to build the botosession.                                                                            | string        | rolesanywhere                               |
+| endpoint         | Roles Anywhere API endpoint to use                                                                                                       | string        | {service_name}.{region_name}.amazonaws.com' |
+| proxies          | Proxy endpoint(s) for use behind private networks with a proxy.                                                                          | dict          | `{}`                                        |
+| proxies_config   | A dictionary of additional proxy configurations.                                                                                         | dict          | `{}`                                        |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,3 +6,11 @@
 ## Signer Class
 
 ::: iam_rolesanywhere_session.IAMRolesAnywhereSigner
+
+## Typed Dict
+
+::: iam_rolesanywhere_session.ProxyConfig
+
+::: iam_rolesanywhere_session.AdditionalProxyConfig
+
+::: iam_rolesanywhere_session.IAMCredentials

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,25 +1,7 @@
 ---
 title: Usage
 ---
-# Configuration Parameters
-
-IAMRoleAnywhereSession will take multiple arguments:
-
-| Name             | Description                                                                                                                              | Type          | Default value |
-|------------------|------------------------------------------------------------------------------------------------------------------------------------------|---------------|---------------|
-| profile_arn      | The Amazon Resource Name (ARN) of the profile.                                                                                           | string        |     None      |
-| role_arn         | The Amazon Resource Name (ARN) of the role to assume.                                                                                    | string        |     None      |
-| trust_anchor_arn | The Amazon Resource Name (ARN) of the trust anchor.                                                                                      | string        |     None      |
-| certificate      | The x509 certificate file, in PEM format.                                                                                                | path or bytes |     None      |
-| private_key      | The certificate private key file, in PEM Format.                                                                                         | path or bytes |     None      |
-| passphrase       | The passphrase use to decrypt private key file.                                                                                          | string        |     None      |
-| region           | The name of the region where you configured IAM Roles Anywhere.                                                                          | string        |   us-east-1   |
-| session_duration | The duration, in seconds, of the role session. The value specified can  range from 900 seconds (15 minutes) up to 3600 seconds (1 hour). | int           |     3600      |
-| service_name     | An identifier for the service, used to build the botosession.                                                                            | string        | rolesanywhere |
-| endpoint         | Roles Anywhere API endpoint to use                                                                                                       | string        | {service_name}.{region_name}.amazonaws.com' |
-
-
-# Examples
+# Usages
 
 ## Minimal implementation
 
@@ -118,5 +100,29 @@ creds = IAMRolesAnywhereSession(
 ACCESS_KEY = creds.access_key
 SECRET_KEY = creds.secret_key
 TOKEN = creds.token
+
+```
+
+## Use proxy configuration
+
+Environment variables (`http_proxy`, `https_proxy` and `no_proxy`) are automatically used.
+
+> Proxy configuration are automatically added to botocore session.
+
+```python
+from iam_rolesanywhere_session import IAMRolesAnywhereSession
+
+roles_anywhere_session = IAMRolesAnywhereSession(
+    profile_arn="arn:aws:rolesanywhere:eu-central-1:************:profile/a6294488-77cf-4d4a-8c5c-40b96690bbf0",
+    role_arn="arn:aws:iam::************:role/IAMRolesAnywhere-01",
+    trust_anchor_arn="arn:aws:rolesanywhere:eu-central-1::************::trust-anchor/4579702c-9abb-47c2-88b2-c734e0b29539",
+    certificate='certificate.pem',
+    private_key='privkey.pem',
+    region="eu-central-1",
+    proxies={'https': "http://URL:PORT", 'http': "http://URL:PORT"}
+).get_session()
+
+s3 = roles_anywhere_session.client("s3")
+print(s3.list_buckets())
 
 ```

--- a/src/iam_rolesanywhere_session/iam_rolesanywhere_session.py
+++ b/src/iam_rolesanywhere_session/iam_rolesanywhere_session.py
@@ -60,6 +60,7 @@ class IAMRolesAnywhereSession:
         region: Optional[str] = "us-east-1",
         service_name: Optional[str] = "rolesanywhere",
         endpoint: Optional[str] = None,
+        proxy: Optional[dict] = {},
     ) -> None:
         # IAM Roles Anywhere variables
 
@@ -81,7 +82,8 @@ class IAMRolesAnywhereSession:
         self.private_key_passphrase = private_key_passphrase
         self.private_key = private_key
 
-        self._session = URLLib3Session()
+        self.proxy = proxy
+        self._session = URLLib3Session(proxies=self.proxy)
 
         self._request_signer = IAMRolesAnywhereSigner(
             certificate=self.certificate,

--- a/src/iam_rolesanywhere_session/iam_rolesanywhere_session.py
+++ b/src/iam_rolesanywhere_session/iam_rolesanywhere_session.py
@@ -46,6 +46,45 @@ class IAMCredentials(TypedDict):
     expiry_time: str
 
 
+class ProxyConfig(TypedDict):
+    """A dictionary of proxy servers to use by protocol or
+        endpoint
+
+    Args:
+        http_proxy (str): http proxy server with port
+        https_proxy (str): https proxy server with port
+
+    Examples:
+        `{'https': "http://URL:PORT", 'http': "http://URL:PORT"}`
+    """
+
+    http_proxy: str
+    https_proxy: str
+
+
+class AdditionalProxyConfig(TypedDict):
+    """A dictionary of additional proxy configurations.
+
+    Args:
+        * proxy_ca_bundle (str): -- The path to a custom certificate bundle to use
+            when establishing SSL/TLS connections with proxy.
+        * proxy_client_cert (str,tuple): -- The path to a certificate for proxy
+          TLS client authentication.
+          When a str is provided it is treated as a path to a proxy client
+          certificate. When a two element tuple is provided, it will be
+          interpreted as the path to the client certificate, and the path
+          to the certificate key.
+        * proxy_use_forwarding_for_http (bool): -- For HTTPS proxies,
+          forward your requests to HTTPS destinations with an absolute
+          URI. We strongly recommend you only use this option with
+          trusted or corporate proxies. Value must be boolean.
+    """
+
+    proxy_ca_bundle: str
+    proxy_client_cert: Union[str, tuple]
+    proxy_use_forwarding_for_https: bool
+
+
 class IAMRolesAnywhereSession:
     def __init__(
         self,
@@ -60,7 +99,8 @@ class IAMRolesAnywhereSession:
         region: Optional[str] = "us-east-1",
         service_name: Optional[str] = "rolesanywhere",
         endpoint: Optional[str] = None,
-        proxy: Optional[dict] = {},
+        proxies: Optional[ProxyConfig] = {},
+        proxies_config: Optional[AdditionalProxyConfig] = {},
     ) -> None:
         # IAM Roles Anywhere variables
 
@@ -82,8 +122,11 @@ class IAMRolesAnywhereSession:
         self.private_key_passphrase = private_key_passphrase
         self.private_key = private_key
 
-        self.proxy = proxy
-        self._session = URLLib3Session(proxies=self.proxy)
+        self.proxies = proxies
+        self.proxies_config = proxies_config
+        self._session = URLLib3Session(
+            proxies=self.proxies, proxies_config=self.proxies_config
+        )
 
         self._request_signer = IAMRolesAnywhereSigner(
             certificate=self.certificate,
@@ -108,6 +151,11 @@ class IAMRolesAnywhereSession:
 
         # Default session region
         session.set_config_variable("region", self.region_name)
+
+        # Set proxy configuration
+        session.set_config_variable("proxies", self.proxies)
+        session.set_config_variable("proxies_config", self.proxies_config)
+
         for k, v in kwargs.items():
             session.set_config_variable(k, v)
         return Session(botocore_session=session)


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:* Allow proxies for use behind a private or corporate network that requires proxy configurations for internet bound traffic.  This defaults to no proxy configurations and is optional to allow uses without a proxy to continue unaffected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
