### PR TITLE
Throw an error when credentials cannot be created

### DIFF
--- a/src/iam_rolesanywhere_session/iam_rolesanywhere_session.py
+++ b/src/iam_rolesanywhere_session/iam_rolesanywhere_session.py
@@ -158,8 +158,13 @@ class IAMRolesAnywhereSession:
         log.debug(credentials_request_resp.text)
 
         # Load the results
+        credentials_request_response_text = json.loads(credentials_request_resp.text)
+        if credentials_request_resp.status_code > 299:
+            log.error(credentials_request_response_text["message"])
+            raise Exception(credentials_request_response_text["message"])
+            
         aws_creds = (
-            json.loads(credentials_request_resp.text)
+            credentials_request_response_text
             .get("credentialSet")[0]
             .get("credentials")
         )


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:* Catch when there is an error making credentials and throw an exception instead with a proper message instead of making the user interpret another error message.  This is what is thrown when there's any sort of error:

`(<class 'TypeError'>, TypeError("'NoneType' object is not subscriptable"), <traceback object at 0x1108e7d00>)`

Instead, this will return the error from the AWS API call that providers a human friendly message like `Exception: Requested Role isn't one of those listed in the Profile.`.

I know it's pretty lazy to use the base exception class but there's precedence within this code base for using it, and well, I'm being lazy as I try to make this codebase work for my needs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
