### PR TITLE
fix: replace depreciated OpenSSL.crypto.sign by cryptography.hazmat.primitives.asymmetric

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 ]
 
 dependencies = [
-    "pyOpenSSL>=22.0.0",
     "boto3>=1.24.55",
     "botocore>=1.27.55",
     "cryptography>=37.0.4",

--- a/src/iam_rolesanywhere_session/iam_rolesanywhere_session.py
+++ b/src/iam_rolesanywhere_session/iam_rolesanywhere_session.py
@@ -399,7 +399,7 @@ class IAMRolesAnywhereSigner(SigV4Auth):
     @staticmethod
     def __load_private_key(
         private_key: Union[str, bytes], passphrase: Optional[bytes] = None
-    ) -> RSAPrivateKey | EllipticCurvePrivateKey:
+    ) -> Union[RSAPrivateKey, EllipticCurvePrivateKey]:
         """Load the private key
 
         Args:


### PR DESCRIPTION
*Issue #, if available:* #15

*Description of changes:*
Replaces depreciated `OpenSSL.crypto.sign` method (see [OpenSSL 24.3.0 backward-incompatible changes](https://www.pyopenssl.org/en/stable/changelog.html#backward-incompatible-changes)) by cryptography asymmetric primitives. `pyOpenSSL` is not used anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
