### PR TITLE
Raise API error before parsing response

### DIFF
--- a/src/iam_rolesanywhere_session/iam_rolesanywhere_session.py
+++ b/src/iam_rolesanywhere_session/iam_rolesanywhere_session.py
@@ -210,11 +210,11 @@ class IAMRolesAnywhereSession:
 
         log.debug(credentials_request_resp.text)
 
-        # Load the results
-        credentials_request_response_text = json.loads(credentials_request_resp.text)
         if credentials_request_resp.status_code > 299:
             log.error(credentials_request_response_text["message"])
             raise Exception(credentials_request_response_text["message"])
+        # Load the results
+        credentials_request_response_text = json.loads(credentials_request_resp.text)
             
         aws_creds = (
             credentials_request_response_text


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In case of an error response from the API, the correct error is not logged / raised if the response in not a valid JSON (which seems to be the case). Raise before decoding in case of an error response.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
