### PR TITLE
fix: License classifiers are deprecated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ requires-python = ">=3.8"
 
 classifiers = [
     "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
 ]
 


### PR DESCRIPTION
*Description of changes:*

Remove the License classifier from pyproject.toml as per https://peps.python.org/pep-0639/#deprecate-license-classifiers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
