### PR TITLE
fix: upgrade mkdocs-material to >=9.5.32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = [ "readme"]
 [project.optional-dependencies]
 dev = [
     "mkdocs",
-    "mkdocs-material",
+    "mkdocs-material>=9.5.32",
     "mkdocstrings",
     "mkdocstrings-python",
     "pre-commit",


### PR DESCRIPTION
Upgrades mkdocs-material dependency to >=9.5.32 which includes security improvements.

No functional changes to documentation content or search functionality.